### PR TITLE
changed to alternate wayback cdx server

### DIFF
--- a/cdx_toolkit/__init__.py
+++ b/cdx_toolkit/__init__.py
@@ -258,7 +258,7 @@ def fetch_wb_content(capture):
     timestamp = capture['timestamp']
 
     prefix = 'https://web.archive.org/web'
-    url = '{}/{}{}/{}'.format(prefix, timestamp, 'js_', quote(fetch_url))
+    url = '{}/{}{}/{}'.format(prefix, timestamp, 'id_', quote(fetch_url))
 
     resp = myrequests_get(url)
     content_bytes = resp.content

--- a/cdx_toolkit/__init__.py
+++ b/cdx_toolkit/__init__.py
@@ -318,7 +318,7 @@ class CDXFetcher:
         if source == 'cc':
             self.raw_index_list = get_cc_endpoints()
         elif source == 'ia':
-            self.index_list = ('https://web.archive.org/cdx/search/cdx',)
+            self.index_list = ('https://web.archive.org/web/timemap/json',)
         elif source.startswith('https://') or source.startswith('http://'):
             self.index_list = (source,)
         else:

--- a/cdx_toolkit/__init__.py
+++ b/cdx_toolkit/__init__.py
@@ -411,8 +411,8 @@ class CDXFetcher:
         if 'filter' in params:
             params['filter'] = munge_filter(params['filter'], self.source)
 
-        if 'limit' not in params:
-            params['limit'] = 1000
+#        if 'limit' not in params:
+#            params['limit'] = 1000
         if self.source == 'cc':
             apply_cc_defaults(params)
 

--- a/scripts/cdx_iter
+++ b/scripts/cdx_iter
@@ -21,6 +21,7 @@ ARGS.add_argument('--cc-sort', action='store', help='default mixed, alternativel
 ARGS.add_argument('--from', action='store')
 ARGS.add_argument('--to', action='store')
 ARGS.add_argument('--filter', action='store', help='see CDX API documentation for usage')
+ARGS.add_argument('--collapse', action='store')
 ARGS.add_argument('--all-fields', action='store_true')
 ARGS.add_argument('--fields', action='store', default='url,status,timestamp', help='try --all-fields if you need the list')
 ARGS.add_argument('--jsonl', action='store_true')


### PR DESCRIPTION
https://web.archive.org/web/timemap/json and https://web.archive.org/web/timemap/xd return an extra "filename" field like pywb/common crawl do. Filenames correspond to warc and arc files located in archive.org collection items. Item metadata can be accessed using archive.org's metadata api and files which are publicly accessible can be downloaded in whole or in part similarly to commoncrawl warcs on s3.

http://blog.archive.org/2013/07/04/metadata-api/