### PR TITLE
Fixes pip install with python 3.10 and 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author_email='lindahl@pbm.com',
     url='https://github.com/cocrawler/cdx_toolkit',
     packages=packages,
-    python_requires=">=3.6.*",
+    python_requires=">=3.6",
     extras_require=extras_require,
     setup_requires=['setuptools-scm'],
     install_requires=requires,


### PR DESCRIPTION
Tested with both python 3.10 and 3.11, install works with this change. Without this change, I get the following error (attempted both with `python -m venv --upgrade-deps  .venv; source .venv/bin/activate ; pip install cdx_toolkit`. (where the python command used to generate the venv points to the specific version of python for each version)