### PR TITLE
Raise an error on 429 (rate limiting)

### DIFF
--- a/cdx_toolkit/myrequests.py
+++ b/cdx_toolkit/myrequests.py
@@ -58,6 +58,9 @@ def myrequests_get(url, params=None, headers=None, cdx=False, allow404=False):
                 # 503=slow down, 50[24] are temporary outages, 500=Amazon S3 generic error
                 # CC takes a 503 from storage and then emits a 500 with error text in resp.text
                 # I have never seen IA or CC send 429 or 509, but just in case...
+
+                if resp.status_code in {429}:
+                    raise requests.exceptions.ConnectionError("429 rate limited")
                 retries += 1
                 if retries > 5:
                     LOGGER.warning('retrying after 1s for %d', resp.status_code)


### PR DESCRIPTION
IA started rate limiting requests some time ago and subsequently sending 429s out. Currently the error handling for 429 is to just retry every second, which is neither API friendly nor effective.

This PR raises an error on 429 thus passing the responsibility of handling the rate limiting to the user. 

The way this PR solves this is neither overly elegant nor very nice, but it was a quick solution.