### PR TITLE
End Python 3.7 support

### DIFF
--- a/.github/workflows/ci-slow.yaml
+++ b/.github/workflows/ci-slow.yaml
@@ -16,9 +16,6 @@ jobs:
           - python-version: '3.12'
             os: macos-latest
             EXTRA: true
-          - python-version: '3.7'
-            os: windows-latest
-            EXTRA: true
           - python-version: '3.12'
             os: windows-latest
             EXTRA: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       max-parallel: 1  # avoids ever triggering a rate limit
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest]
         EXTRA: [false]  # used to force includes to get included
         include:
@@ -25,9 +25,6 @@ jobs:
             EXTRA: true
             env:
               LOGLEVEL=DEBUG
-          - python-version: '3.7'
-            os: ubuntu-20.04  # oldest version on github actions
-            EXTRA: true
 
     steps:
       - name: checkout

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     author_email='lindahl@pbm.com',
     url='https://github.com/cocrawler/cdx_toolkit',
     packages=packages,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     extras_require=extras_require,
     setup_requires=['setuptools-scm'],
     install_requires=requires,
@@ -60,7 +60,7 @@ setup(
         'Programming Language :: Python',
         #'Programming Language :: Python :: 3.5',  # setuptools-scm problem
         #'Programming Language :: Python :: 3.6',  # not offered in github actions
-        'Programming Language :: Python :: 3.7',
+        # 'Programming Language :: Python :: 3.7',  # end-of-life in 2023
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
This PR ends the support for Python 3.7 (official end of support already in 2023). It updates the CI and package information accordingly.