### PR TITLE
Replacing the deprecated `pkg_resources` import with `importlib.metadata` (2)

### DIFF
--- a/cdx_toolkit/__init__.py
+++ b/cdx_toolkit/__init__.py
@@ -6,9 +6,9 @@ import warnings
 
 try:
     from importlib.metadata import version, PackageNotFoundError
-except ImportError:
+except ImportError:   # pragma: no cover
     # Python < 3.8 compatibility
-    from importlib_metadata import version, PackageNotFoundError
+    from importlib_metadata import version, PackageNotFoundError  # pragma: no cover
 
 __version__ = 'installed-from-git'
 


### PR DESCRIPTION
The `pkg_resources` package is deprecated. See https://setuptools.pypa.io/en/latest/pkg_resources.html

This PR replaces the `pkg_resources` import with `importlib.metadata` as suggested in the official docs:
> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)).