### PR TITLE
feat: Adding docs via CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to cdx_toolkit
+
+We welcome contributions to cdx_toolkit! Whether you're adding new features, improving documentation, or fixing bugs, your help is greatly appreciated.
+
+## Tests
+
+To test code changes, please run our test suite before submitting pull requests:
+
+```bash
+# all tests (same as CI)
+make test
+
+# simple unit tests without integration tests
+make unit
+```
+
+By default, all remote requests are mocked. To change this behaviour and actually call remote APIs (if you run this from a whitelisted IP address), the following environment variable can be set:
+
+```bash
+export DISABLE_MOCK_RESPONSES=1
+```
+
+If the remote APIs change, new mock data can be semi-automatically collected by setting another environment variable,  running corresponding unit tests, and overwriting existing mock data in `tests/data/mock_responses`:
+
+```bash
+# set environment variable (DISABLE_MOCK_RESPONSES should not be set)
+export SAVE_MOCK_RESPONSES=./tmp/mock_responses
+    
+# run the test for what mock data should be saved to $SAVE_MOCK_RESPONSES/<test_file>/<test_func>.jsonl
+pytest tests/test_cli.py::test_basics
+```
+
+## Code format & linting
+
+Please following the definitions from `.editorconfig` and `.flake8`.

--- a/README.md
+++ b/README.md
@@ -273,6 +273,11 @@ instead of a partial one.
 
 cdx_toolkit has reached the beta-testing stage of development.
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing 
+and running tests.
+
 ## License
 
 Copyright 2018-2020 Greg Lindahl and others


### PR DESCRIPTION
This PR adds infos on running tests as documentation.

- Fixes https://github.com/cocrawler/cdx_toolkit/issues/56
- The common practice for developer guidelines etc. is to have them in a CONTRIBUTING.md.