### PR TITLE
ci: add publish_pypi workflow for trusted-publisher PyPI releases

### DIFF
--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -1,0 +1,195 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: "Semver component to bump (patch/minor/major)"
+        type: choice
+        required: true
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      dry_run:
+        description: "Dry run: publish only to TestPyPI (with .devN suffix); do not tag, do not publish to PyPI, do not create GitHub release."
+        type: boolean
+        required: true
+        default: true
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  bump-and-build:
+    name: Compute version, build, and (if real) tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure tags are present
+        run: git fetch --tags --force --prune
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade build twine packaging
+
+      - name: Compute next version
+        id: version
+        env:
+          BUMP: ${{ inputs.version_bump }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          LATEST="$(git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)"
+          if [ -z "${LATEST}" ]; then
+            LATEST="0.0.0"
+          fi
+          echo "Latest semver tag: ${LATEST}"
+          IFS=. read -r MAJOR MINOR PATCH <<< "${LATEST}"
+          case "${BUMP}" in
+            patch) NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+            minor) NEXT="${MAJOR}.$((MINOR + 1)).0" ;;
+            major) NEXT="$((MAJOR + 1)).0.0" ;;
+            *) echo "Unknown bump: ${BUMP}" >&2; exit 1 ;;
+          esac
+          if [ "${DRY_RUN}" = "true" ]; then
+            VERSION="${NEXT}.dev${RUN_NUMBER}"
+          else
+            VERSION="${NEXT}"
+          fi
+          python -c "from packaging.version import Version; Version('${VERSION}')"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "Computed version: ${VERSION}"
+
+      - name: Build sdist + wheel
+        env:
+          SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CDX_TOOLKIT: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          rm -rf dist/
+          python -m build
+          ls -l dist/
+
+      - name: twine check
+        run: twine check dist/*
+
+      - name: Verify built version matches computed version
+        env:
+          EXPECTED: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          ls dist/cdx_toolkit-"${EXPECTED}".tar.gz
+          ls dist/cdx_toolkit-"${EXPECTED}"-*.whl
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+      - name: Create and push annotated tag (real release only)
+        if: ${{ inputs.dry_run != true }}
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${VERSION}" -m "Release ${VERSION}"
+          git push origin "${VERSION}"
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    needs: bump-and-build
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/cdx-toolkit/${{ needs.bump-and-build.outputs.version }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [bump-and-build, publish-testpypi]
+    if: ${{ inputs.dry_run != true }}
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/project/cdx-toolkit/${{ needs.bump-and-build.outputs.version }}
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: [bump-and-build, publish-pypi]
+    if: ${{ inputs.dry_run != true }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout the release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-and-build.outputs.version }}
+          fetch-depth: 0
+
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.bump-and-build.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh release create "${VERSION}" dist/* \
+            --title "${VERSION}" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish_pypi.yaml` — a manually-dispatched release pipeline that uses **PyPI Trusted Publishing** (OIDC, no API tokens) to publish `cdx_toolkit` to TestPyPI and PyPI, then cuts a GitHub Release.

Replaces the manual `make dist` flow currently documented in the `Makefile`. The workflow is `workflow_dispatch` only — releases never happen automatically on push.

## Why this design

The project uses **`setup.py` + setuptools-scm** (version derived from git tags, no `pyproject.toml`, no `uv`/`uv.lock`). The workflow keeps this versioning model — the **git tag is the source of truth**. The bare-tag convention (`0.9.39`, no `v`) documented in the `Makefile` is preserved.

Trusted publishing is already configured on:
- **PyPI** — environment `release`
- **TestPyPI** — environment `testpypi`

Both bound to workflow filename `publish_pypi.yaml`.

## Workflow inputs

| Input | Type | Default | Effect |
|---|---|---|---|
| `version_bump` | choice (`patch`/`minor`/`major`) | `patch` | Which semver component to bump from the latest tag |
| `dry_run` | boolean | **`true`** | If `true`: `.devN`-suffixed build → TestPyPI only; no tag push, no PyPI, no GitHub Release |

The `dry_run=true` default is intentional — the very first dispatch after merging is harmless.

## Job graph

```
bump-and-build  ──►  publish-testpypi  ──►  publish-pypi  ──►  github-release
                                            (skipped if         (skipped if
                                              dry_run)            dry_run)
```

1. **`bump-and-build`** — checkout (full history + tags), set up Python 3.13, `pip install build twine packaging`, compute the next version by parsing the latest `^[0-9]+\.[0-9]+\.[0-9]+$` tag and bumping per `version_bump` (or appending `.dev${GITHUB_RUN_NUMBER}` for dry runs), validate with `packaging.version.Version`, build sdist + wheel with `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_CDX_TOOLKIT` set so the artifact carries the intended version *before* any tag exists, run `twine check`, verify built filenames, upload `dist/`. **Real-release-only final step**: create + push annotated tag.
2. **`publish-testpypi`** — environment `testpypi`, `id-token: write`. Downloads the artifact and publishes to `https://test.pypi.org/legacy/` with `skip-existing: true`. Runs for both dry-run and real release.
3. **`publish-pypi`** — environment `release`, `id-token: write`. Skipped on dry runs. No `skip-existing` (hard fail on accidental version reuse).
4. **`github-release`** — checks out the tag, downloads the artifact, runs `gh release create "${VERSION}" dist/* --title "${VERSION}" --generate-notes --verify-tag`.

Concurrency lock `group: publish, cancel-in-progress: false` prevents racing dispatches.

## Step-by-step usage

### Dry run (recommended first invocation)

```
gh workflow run publish_pypi.yaml -f version_bump=patch -f dry_run=true
```

Expected:
- Latest tag is `0.9.38` → computed version is `0.9.39.dev<run_number>`.
- `bump-and-build` produces `dist/cdx_toolkit-0.9.39.dev<run>.tar.gz` + matching wheel.
- `publish-testpypi` succeeds; release visible at `https://test.pypi.org/project/cdx-toolkit/0.9.39.dev<run>/`.
- `publish-pypi` and `github-release` are skipped.
- **No git tag is pushed.**

### Real patch release

```
gh workflow run publish_pypi.yaml -f version_bump=patch -f dry_run=false
```

Expected (latest tag `0.9.38` → release `0.9.39`):
1. `bump-and-build` builds `cdx_toolkit-0.9.39.tar.gz` + wheel and pushes annotated tag `0.9.39` to `origin`.
2. `publish-testpypi` uploads to TestPyPI (idempotent if re-run).
3. `publish-pypi` uploads to PyPI; release live at `https://pypi.org/project/cdx-toolkit/0.9.39/`.
4. `github-release` cuts the GitHub Release on tag `0.9.39` with auto-generated notes and the sdist + wheel attached.

### Verifying after a real release

```
git fetch --tags
git tag --list | grep '^0\.9\.39$'                  # tag exists locally
pip install --force-reinstall cdx_toolkit==0.9.39    # in a clean venv
pip show cdx_toolkit                                  # reports 0.9.39
```

## Operational notes

- **Tag pushed before publish.** If a publish job fails after the tag is pushed, the tag persists and a retry would conflict. Recovery: `git push --delete origin <tag>` and re-dispatch. (Matches the source workflow's behavior; not overengineered into a multi-step rollback.)
- **Required secrets.** None — trusted publishing replaces tokens. The default `GITHUB_TOKEN` is sufficient for tag push and `gh release create`.
- **Required environments.** Both `testpypi` and `release` GitHub Environments must exist with their respective trusted-publisher configs on test.pypi.org and pypi.org. (User confirmed these are configured.)
- **Permissions per job.**
  - `bump-and-build`: `contents: write` (push tag).
  - `publish-testpypi`, `publish-pypi`: `id-token: write` only.
  - `github-release`: `contents: write` (create release).

## Test plan

- [ ] Merge to `main` (workflow file must be on the default branch before `workflow_dispatch` is dispatchable).
- [ ] Run dry run from `main`: `gh workflow run publish_pypi.yaml -f version_bump=patch -f dry_run=true`. Verify (a) all four jobs behave as expected, (b) `0.9.39.dev<run>` appears on TestPyPI, (c) no tag is pushed, (d) `publish-pypi` and `github-release` are skipped.
- [ ] If anything needs tweaking, iterate on a branch and re-test with `gh workflow run publish_pypi.yaml --ref my-branch -f dry_run=true` (the workflow file must already be on `main` once for `--ref` dispatches to work).
- [ ] When ready: real patch release `gh workflow run publish_pypi.yaml -f version_bump=patch -f dry_run=false`. Verify tag `0.9.39` on origin, release on pypi.org, GitHub Release page populated, and `pip install cdx_toolkit==0.9.39` works in a clean venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)