### PR TITLE
ci: bump GitHub Actions to Node 24-compatible major versions

### DIFF
--- a/.github/workflows/cc-server-check.yaml
+++ b/.github/workflows/cc-server-check.yaml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fail2ban-test-results-${{ github.run_number }}
           path: fail2ban_test_results.json

--- a/.github/workflows/ci-slow.yaml
+++ b/.github/workflows/ci-slow.yaml
@@ -24,10 +24,10 @@ jobs:
             EXTRA: true
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,10 +44,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,12 +73,12 @@ jobs:
 
       - name: Disable S3 unit tests for Python 3.8 (botocore requires Python 3.9+)
         if: ${{ startsWith(matrix.python-version, '3.8') }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             core.exportVariable('CDXT_DISABLE_S3_TESTS', '1')
       - name: Set environment variables for faster unit tests (requests are mocked)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             core.exportVariable('CDXT_MAX_ERRORS', '2')
@@ -116,10 +116,10 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -132,7 +132,7 @@ jobs:
         run: pip install .[test]
 
       - name: Set environment variables for faster unit tests (requests are mocked)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             core.exportVariable('CDXT_MAX_ERRORS', '2')

--- a/.github/workflows/publish_pypi.yaml
+++ b/.github/workflows/publish_pypi.yaml
@@ -35,7 +35,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout (full history + tags)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
         run: git fetch --tags --force --prune
 
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 
@@ -102,7 +102,7 @@ jobs:
           ls dist/cdx_toolkit-"${EXPECTED}"-*.whl
 
       - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -131,7 +131,7 @@ jobs:
       contents: read
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -155,7 +155,7 @@ jobs:
       contents: read
     steps:
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -172,13 +172,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout the release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.bump-and-build.outputs.version }}
           fetch-depth: 0
 
       - name: Download dist artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
## Why

GitHub is deprecating the Node.js 20 runtime for actions and will **force-migrate to Node 24 on 2026-06-16** (Node 20 removed from runners 2026-09-16). Several of our workflows pin `actions/*` at majors that still run on Node 20, which currently produces deprecation annotations (e.g. on the recent [publish run](https://github.com/commoncrawl/cdx_toolkit/actions/runs/26563335480)) and will break once the migration is forced.

## What

Bump all `actions/*` to their current Node 24-based major versions across every workflow:

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/github-script` | v7 | v9 |

Files touched: `ci.yaml`, `ci-slow.yaml`, `cc-server-check.yaml`, `publish_pypi.yaml`.

`pypa/gh-action-pypi-publish@release/v1` is unaffected (separate publisher, already on a maintained branch).

## Notes

- `upload-artifact@v7` and `download-artifact@v8` share the same v4+ artifact backend, so the upload-in-`bump-and-build` / download-in-later-jobs flow in `publish_pypi.yaml` remains compatible.
- No behavioral changes beyond runtime; `ci.yaml` will exercise checkout/setup-python/github-script on this PR.